### PR TITLE
Using Anaconda3/2022.05 and change the output file's relative path to…

### DIFF
--- a/HPC/sample_batch.sh
+++ b/HPC/sample_batch.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #SBATCH --nodes=1  # Specify a number of nodes
 #SBATCH --mem=5G  # Request 5 gigabytes of real memory (mem)
-#SBATCH --output=../Output/COM6012_Lab1.txt  # This is where your output and errors are logged
+#SBATCH --output=./Output/COM6012_Lab1.txt  # This is where your output and errors are logged
 #SBATCH --mail-user=username@sheffield.ac.uk  # Request job update email notifications, remove this line if you don't want to be notified
 
 module load Java/17.0.4
-module load Anaconda3/2022.10
+module load Anaconda3/2022.05
 
 source activate myspark
 


### PR DESCRIPTION
Change the default anaconda version to 2022.05 and relative path of output file to be the same in the lab sheet